### PR TITLE
Update DeliveryStatusCommand Command Syntax

### DIFF
--- a/src/main/java/seedu/address/logic/commands/delivery/DeliveryStatusCommand.java
+++ b/src/main/java/seedu/address/logic/commands/delivery/DeliveryStatusCommand.java
@@ -28,8 +28,8 @@ public class DeliveryStatusCommand extends DeliveryCommand {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the status of the delivery identified "
             + "by the ID of the delivery. Existing status will be overwritten by the input status.\n"
-            + "Parameters: STATUS (must be one of CREATED/SHIPPED/COMPLETED/CANCELLED) "
-            + "ID (must be a integer representing a valid ID)\n"
+            + "Parameters: ID (must be a integer representing a valid ID) "
+            + "STATUS (must be one of CREATED/SHIPPED/COMPLETED/CANCELLED)\n"
             + "Example: " + COMMAND_WORD + " COMPLETED 1";
 
     public static final String MESSAGE_EDIT_DELIVERY_SUCCESS = "Edited Delivery: %1$s";

--- a/src/main/java/seedu/address/logic/parser/delivery/DeliveryStatusCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/delivery/DeliveryStatusCommandParser.java
@@ -17,7 +17,7 @@ import seedu.address.model.delivery.DeliveryStatus;
 public class DeliveryStatusCommandParser implements Parser<DeliveryStatusCommand> {
 
     private static final Pattern ARGUMENT_FORMAT = Pattern.compile(
-        "^(?<status>\\w+)\\s+(?<id>\\d+)$"
+        "^(?<id>\\d+)\\s+(?<status>\\w+)$"
     );
 
     /**

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -85,7 +85,7 @@ public class AddressBookParserTest {
     public void parseCommand_deliveryStatus() throws Exception {
         DeliveryStatusCommand command = (DeliveryStatusCommand) parser.parseCommand(
                 DeliveryStatusCommand.COMMAND_WORD + " "
-                        + DeliveryStatus.COMPLETED + " " + GABRIELS_MILK.getDeliveryId());
+                        + GABRIELS_MILK.getDeliveryId() + " " + DeliveryStatus.COMPLETED);
         assertEquals(new DeliveryStatusCommand(GABRIELS_MILK.getDeliveryId(), DeliveryStatus.COMPLETED), command);
     }
 

--- a/src/test/java/seedu/address/logic/parser/delivery/DeliveryStatusCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/delivery/DeliveryStatusCommandParserTest.java
@@ -27,59 +27,59 @@ public class DeliveryStatusCommandParserTest {
     public void parse_allFields_success() {
         // CREATED
         DeliveryStatusCommand deliveryStatusCommand = new DeliveryStatusCommand(1, DeliveryStatus.CREATED);
-        assertParseSuccess(parser, VALID_STATUS_CREATED + " 1", deliveryStatusCommand);
+        assertParseSuccess(parser, "1 " + VALID_STATUS_CREATED, deliveryStatusCommand);
 
         // SHIPPED
         deliveryStatusCommand = new DeliveryStatusCommand(1, DeliveryStatus.SHIPPED);
-        assertParseSuccess(parser, VALID_STATUS_SHIPPED + " 1", deliveryStatusCommand);
+        assertParseSuccess(parser, "1 " + VALID_STATUS_SHIPPED, deliveryStatusCommand);
 
         // COMPLETED
         deliveryStatusCommand = new DeliveryStatusCommand(1, DeliveryStatus.COMPLETED);
-        assertParseSuccess(parser, VALID_STATUS_COMPLETED + " 1", deliveryStatusCommand);
+        assertParseSuccess(parser, "1 " + VALID_STATUS_COMPLETED, deliveryStatusCommand);
 
         // CANCELLED
         deliveryStatusCommand = new DeliveryStatusCommand(1, DeliveryStatus.CANCELLED);
-        assertParseSuccess(parser, VALID_STATUS_CANCELLED + " 1", deliveryStatusCommand);
+        assertParseSuccess(parser, "1 " + VALID_STATUS_CANCELLED, deliveryStatusCommand);
     }
 
     @Test
     public void parse_allFieldsExtraSpaceBetween_success() {
         DeliveryStatusCommand deliveryStatusCommand = new DeliveryStatusCommand(1, DeliveryStatus.CREATED);
-        assertParseSuccess(parser, VALID_STATUS_CREATED + "   1", deliveryStatusCommand);
+        assertParseSuccess(parser, "1    " + VALID_STATUS_CREATED, deliveryStatusCommand);
     }
 
     @Test
     public void parse_allFieldsExtraSpaceBefore_success() {
         DeliveryStatusCommand deliveryStatusCommand = new DeliveryStatusCommand(1, DeliveryStatus.CREATED);
-        assertParseSuccess(parser, " " + VALID_STATUS_CREATED + " 1", deliveryStatusCommand);
+        assertParseSuccess(parser, " 1 " + VALID_STATUS_CREATED, deliveryStatusCommand);
     }
 
     @Test
     public void parse_allFieldsExtraSpaceAfter_success() {
         DeliveryStatusCommand deliveryStatusCommand = new DeliveryStatusCommand(1, DeliveryStatus.CREATED);
-        assertParseSuccess(parser, " " + VALID_STATUS_CREATED + " 1 ", deliveryStatusCommand);
+        assertParseSuccess(parser, "1 " + VALID_STATUS_CREATED + " ", deliveryStatusCommand);
     }
 
     @Test
     public void parse_statusLowerCase_success() {
         DeliveryStatusCommand deliveryStatusCommand = new DeliveryStatusCommand(1, DeliveryStatus.CREATED);
-        assertParseSuccess(parser, VALID_STATUS_CREATED.toLowerCase() + " 1", deliveryStatusCommand);
+        assertParseSuccess(parser, "1 " + VALID_STATUS_CREATED.toLowerCase(), deliveryStatusCommand);
     }
 
     @Test
     public void parse_statusUpperCase_success() {
         DeliveryStatusCommand deliveryStatusCommand = new DeliveryStatusCommand(1, DeliveryStatus.CREATED);
-        assertParseSuccess(parser, VALID_STATUS_CREATED.toUpperCase() + " 1", deliveryStatusCommand);
+        assertParseSuccess(parser, "1 " + VALID_STATUS_CREATED.toUpperCase(), deliveryStatusCommand);
     }
 
     @Test
     public void parse_invalidStatus_failure() {
-        assertParseFailure(parser, INVALID_STATUS + " 1", DeliveryStatus.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, "1 " + INVALID_STATUS, DeliveryStatus.MESSAGE_CONSTRAINTS);
     }
 
     @Test
     public void parse_invalidAllStatus_failure() {
-        assertParseFailure(parser, "ALL 1", MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, "1 ALL", MESSAGE_INVALID_FORMAT);
     }
 
     @Test
@@ -89,24 +89,24 @@ public class DeliveryStatusCommandParserTest {
 
     @Test
     public void parse_extraWordBeforeStatus_failure() {
-        assertParseFailure(parser, "word " + INVALID_STATUS + " 1", MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, "1 word " + INVALID_STATUS, MESSAGE_INVALID_FORMAT);
     }
 
     @Test
     public void parse_negativeId_failure() {
         assertParseFailure(parser,
-            INVALID_STATUS + " " + INVALID_ID_NEGATIVE, MESSAGE_INVALID_FORMAT);
+            INVALID_ID_NEGATIVE + " " + INVALID_STATUS, MESSAGE_INVALID_FORMAT);
     }
 
     @Test
     public void parse_nanId_failure() {
         assertParseFailure(parser,
-            INVALID_STATUS + " " + INVALID_ID_NAN, MESSAGE_INVALID_FORMAT);
+            INVALID_ID_NAN + " " + INVALID_STATUS, MESSAGE_INVALID_FORMAT);
     }
 
     @Test
     public void parse_extraNumberAfterId_failure() {
         assertParseFailure(parser,
-            INVALID_STATUS + " 1 1", MESSAGE_INVALID_FORMAT);
+            "1 1 " + INVALID_STATUS, MESSAGE_INVALID_FORMAT);
     }
 }


### PR DESCRIPTION
Close #173 

Current Command Syntax follows this format,
`delivery status STATUS CUSTOMER_ID`

Following changes proposed in #173 to a new format in line with other delivery commands where ID comes first, `delivery status CUSTOMER_ID STATUS`