### PR TITLE
Enable assertions in build.gradle file

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -72,4 +72,8 @@ shadowJar {
     archiveFileName = 'addressbook.jar'
 }
 
+run {
+    enableAssertions = true
+}
+
 defaultTasks 'clean', 'test'


### PR DESCRIPTION
In line with week 10 deliverables, to enable assertions in build.gradle

Close #184 