### PR TITLE
Add CustomerViewCommand

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -46,14 +46,12 @@ public class Messages {
      */
     public static String format(Customer customer) {
         final StringBuilder builder = new StringBuilder();
-        builder.append(customer.getName())
-            .append("; Phone: ")
-            .append(customer.getPhone())
-            .append("; Email: ")
-            .append(customer.getEmail())
-            .append("; Address: ")
-            .append(customer.getAddress())
-            .append("; Tags: ");
+        builder.append(String.format("[%d]", customer.getCustomerId()))
+            .append(String.format(" %s", customer.getName()))
+            .append(String.format("\n Phone: %s", customer.getPhone().toString()))
+            .append(String.format("\n Email: %s", customer.getEmail().toString()))
+            .append(String.format("\n Address: %s", customer.getAddress().toString()))
+            .append("\n Tags: ");
         customer.getTags().forEach(builder::append);
         return builder.toString();
     }

--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -20,6 +20,7 @@ public class Messages {
     public static final String MESSAGE_INVALID_DELIVERY_DISPLAYED_INDEX = "The delivery index provided is invalid";
     public static final String MESSAGE_INVALID_DELIVERY_ID = "The delivery ID provided is invalid";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
+    public static final String MESSAGE_DELIVERY_LISTED_OVERVIEW = "%1$d deliveries listed!";
     public static final String MESSAGE_DUPLICATE_FIELDS = "Multiple values specified for the following"
         + "single-valued field(s): ";
 

--- a/src/main/java/seedu/address/logic/commands/customer/CustomerViewCommand.java
+++ b/src/main/java/seedu/address/logic/commands/customer/CustomerViewCommand.java
@@ -1,0 +1,59 @@
+package seedu.address.logic.commands.customer;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX;
+import static seedu.address.logic.Messages.MESSAGE_USER_NOT_AUTHENTICATED;
+
+import java.util.Optional;
+
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.person.Customer;
+
+/**
+ * Represents a CustomerViewCommand which displays a single customer.
+ */
+public class CustomerViewCommand extends CustomerCommand {
+
+    public static final String COMMAND_WORD = CustomerCommand.COMMAND_WORD + " view";
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Displays a single customer.\n"
+        + "Parameters: "
+        + "CUSTOMER_ID\n"
+        + "Example: " + COMMAND_WORD + " "
+        + "1";
+
+    public static final String MESSAGE_SUCCESS = "Customer displayed: %1$s";
+
+    private final int customerId;
+
+    /**
+     * Creates a DeliveryViewCommand to display the specified {@code Delivery}.
+     */
+    public CustomerViewCommand(int customerId) {
+        this.customerId = customerId;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        // User cannot perform this operation before logging in
+        if (!model.getUserLoginStatus()) {
+            throw new CommandException(MESSAGE_USER_NOT_AUTHENTICATED);
+        }
+
+        Optional<Customer> customer = model.getCustomer(customerId);
+
+        if (customer.isEmpty()) {
+            throw new CommandException(MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        }
+
+        return new CommandResult(Messages.format(customer.get()));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+            || (other instanceof CustomerViewCommand // instanceof handles nulls
+            && customerId == ((CustomerViewCommand) other).customerId); // state check
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/delivery/DeliveryFindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/delivery/DeliveryFindCommand.java
@@ -1,0 +1,67 @@
+package seedu.address.logic.commands.delivery;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.Messages.MESSAGE_USER_NOT_AUTHENTICATED;
+
+import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.Command;
+import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.delivery.DeliveryNameContainsKeywordsPredicate;
+
+/**
+ * Finds and lists all deliveries in delivery book whose name contains any of the argument keywords.
+ * Keyword matching is case insensitive.
+ */
+public class DeliveryFindCommand extends Command {
+
+    public static final String COMMAND_WORD = "delivery find";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all deliveries whose names contain any of "
+        + "the specified keywords (case-insensitive) and displays them as a list with ID numbers.\n"
+        + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
+        + "Example: " + COMMAND_WORD + " chocolate vanilla";
+
+    private final DeliveryNameContainsKeywordsPredicate predicate;
+
+    public DeliveryFindCommand(DeliveryNameContainsKeywordsPredicate predicate) {
+        this.predicate = predicate;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+
+        // User cannot perform this operation before logging in
+        if (!model.getUserLoginStatus()) {
+            throw new CommandException(MESSAGE_USER_NOT_AUTHENTICATED);
+        }
+
+        model.updateFilteredDeliveryList(predicate);
+        return new CommandResult(
+            String.format(Messages.MESSAGE_DELIVERY_LISTED_OVERVIEW,
+                model.getFilteredDeliveryList().size()), true);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof DeliveryFindCommand)) {
+            return false;
+        }
+        DeliveryFindCommand otherDeliveryFindCommand = (DeliveryFindCommand) other;
+        return predicate.equals(otherDeliveryFindCommand.predicate);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+            .add("predicate", predicate)
+            .toString();
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/delivery/DeliveryFindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/delivery/DeliveryFindCommand.java
@@ -5,7 +5,6 @@ import static seedu.address.logic.Messages.MESSAGE_USER_NOT_AUTHENTICATED;
 
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
-import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
@@ -15,9 +14,9 @@ import seedu.address.model.delivery.DeliveryNameContainsKeywordsPredicate;
  * Finds and lists all deliveries in delivery book whose name contains any of the argument keywords.
  * Keyword matching is case insensitive.
  */
-public class DeliveryFindCommand extends Command {
+public class DeliveryFindCommand extends DeliveryCommand {
 
-    public static final String COMMAND_WORD = "delivery find";
+    public static final String COMMAND_WORD = DeliveryCommand.COMMAND_WORD + " find";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all deliveries whose names contain any of "
         + "the specified keywords (case-insensitive) and displays them as a list with ID numbers.\n"

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -20,6 +20,7 @@ import seedu.address.logic.commands.customer.CustomerListCommand;
 import seedu.address.logic.commands.delivery.DeliveryAddCommand;
 import seedu.address.logic.commands.delivery.DeliveryCreateNoteCommand;
 import seedu.address.logic.commands.delivery.DeliveryDeleteCommand;
+import seedu.address.logic.commands.delivery.DeliveryFindCommand;
 import seedu.address.logic.commands.delivery.DeliveryListCommand;
 import seedu.address.logic.commands.delivery.DeliveryStatusCommand;
 import seedu.address.logic.commands.delivery.DeliveryViewCommand;
@@ -28,6 +29,7 @@ import seedu.address.logic.commands.user.UserLoginCommand;
 import seedu.address.logic.commands.user.UserLogoutCommand;
 import seedu.address.logic.commands.user.UserRegisterCommand;
 import seedu.address.logic.parser.delivery.DeliveryCreateNoteCommandParser;
+import seedu.address.logic.parser.delivery.DeliveryFindCommandParser;
 import seedu.address.logic.parser.delivery.DeliveryStatusCommandParser;
 import seedu.address.logic.parser.delivery.DeliveryViewCommandParser;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -83,12 +85,6 @@ public class AddressBookParser {
         case ClearCommand.COMMAND_WORD:
             return new ClearCommand();
 
-        case DeliveryAddCommand.COMMAND_WORD:
-            return new DeliveryAddCommandParser().parse(arguments);
-
-        case DeliveryDeleteCommand.COMMAND_WORD:
-            return new DeliveryDeleteCommandParser().parse(arguments);
-
         case FindCommand.COMMAND_WORD:
             return new FindCommandParser().parse(arguments);
 
@@ -105,6 +101,18 @@ public class AddressBookParser {
         case DeliveryViewCommand.COMMAND_WORD:
             return new DeliveryViewCommandParser().parse(arguments);
 
+        case DeliveryListCommand.COMMAND_WORD:
+            return new DeliveryListParser().parse(arguments);
+
+        case DeliveryAddCommand.COMMAND_WORD:
+            return new DeliveryAddCommandParser().parse(arguments);
+
+        case DeliveryDeleteCommand.COMMAND_WORD:
+            return new DeliveryDeleteCommandParser().parse(arguments);
+
+        case DeliveryFindCommand.COMMAND_WORD:
+            return new DeliveryFindCommandParser().parse(arguments);
+
         // ================ System Commands ======================================
         case ExitCommand.COMMAND_WORD:
             return new ExitCommand();
@@ -112,8 +120,7 @@ public class AddressBookParser {
         case HelpCommand.COMMAND_WORD:
             return new HelpCommand();
 
-        case DeliveryListCommand.COMMAND_WORD:
-            return new DeliveryListParser().parse(arguments);
+        // ================ User Commands ========================================
 
         case UserLoginCommand.COMMAND_WORD:
             return new UserLoginCommandParser().parse(arguments);

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -17,6 +17,7 @@ import seedu.address.logic.commands.customer.CustomerAddCommand;
 import seedu.address.logic.commands.customer.CustomerDeleteCommand;
 import seedu.address.logic.commands.customer.CustomerEditCommand;
 import seedu.address.logic.commands.customer.CustomerListCommand;
+import seedu.address.logic.commands.customer.CustomerViewCommand;
 import seedu.address.logic.commands.delivery.DeliveryAddCommand;
 import seedu.address.logic.commands.delivery.DeliveryCreateNoteCommand;
 import seedu.address.logic.commands.delivery.DeliveryDeleteCommand;
@@ -28,6 +29,7 @@ import seedu.address.logic.commands.user.UserDeleteCommand;
 import seedu.address.logic.commands.user.UserLoginCommand;
 import seedu.address.logic.commands.user.UserLogoutCommand;
 import seedu.address.logic.commands.user.UserRegisterCommand;
+import seedu.address.logic.parser.customer.CustomerViewCommandParser;
 import seedu.address.logic.parser.delivery.DeliveryCreateNoteCommandParser;
 import seedu.address.logic.parser.delivery.DeliveryFindCommandParser;
 import seedu.address.logic.parser.delivery.DeliveryStatusCommandParser;
@@ -81,6 +83,9 @@ public class AddressBookParser {
 
         case CustomerDeleteCommand.COMMAND_WORD:
             return new CustomerDeleteCommandParser().parse(arguments);
+
+        case CustomerViewCommand.COMMAND_WORD:
+            return new CustomerViewCommandParser().parse(arguments);
 
         case ClearCommand.COMMAND_WORD:
             return new ClearCommand();

--- a/src/main/java/seedu/address/logic/parser/customer/CustomerViewCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/customer/CustomerViewCommandParser.java
@@ -1,0 +1,47 @@
+package seedu.address.logic.parser.customer;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import seedu.address.logic.commands.customer.CustomerViewCommand;
+import seedu.address.logic.parser.Parser;
+import seedu.address.logic.parser.ParserUtil;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new DeliveryViewCommand object
+ */
+public class CustomerViewCommandParser implements Parser<CustomerViewCommand> {
+
+    private static final Pattern ARGUMENT_FORMAT = Pattern.compile(
+        "^(?<id>\\d+)$"
+    );
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the CustomerViewCommand
+     * and returns an CustomerViewCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    @Override
+    public CustomerViewCommand parse(String args) throws ParseException {
+        if (args.isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                CustomerViewCommand.MESSAGE_USAGE));
+        }
+
+        final Matcher matcher = ARGUMENT_FORMAT.matcher(args.trim().toUpperCase());
+        if (!matcher.matches()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                CustomerViewCommand.MESSAGE_USAGE));
+        }
+
+        final String id = matcher.group("id");
+
+        int customerId = ParserUtil.parseId(id);
+
+        return new CustomerViewCommand(customerId);
+    }
+
+}

--- a/src/main/java/seedu/address/logic/parser/delivery/DeliveryFindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/delivery/DeliveryFindCommandParser.java
@@ -1,0 +1,33 @@
+package seedu.address.logic.parser.delivery;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import java.util.Arrays;
+
+import seedu.address.logic.commands.delivery.DeliveryFindCommand;
+import seedu.address.logic.parser.Parser;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.delivery.DeliveryNameContainsKeywordsPredicate;
+
+/**
+ * Parses input arguments and creates a new DeliveryFindCommand object
+ */
+public class DeliveryFindCommandParser implements Parser<DeliveryFindCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the DeliveryFindCommand
+     * and returns a DeliveryFindCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public DeliveryFindCommand parse(String args) throws ParseException {
+        String trimmedArgs = args.trim();
+        if (trimmedArgs.isEmpty()) {
+            throw new ParseException(
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeliveryFindCommand.MESSAGE_USAGE));
+        }
+
+        String[] nameKeywords = trimmedArgs.split("\\s+");
+
+        return new DeliveryFindCommand(new DeliveryNameContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
+    }
+}

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -83,6 +83,14 @@ public interface Model {
     ReadOnlyBook<Customer> getAddressBook();
 
     /**
+     * Returns an optional containing a customer with the given id.
+     *
+     * @param id the id of the customer
+     * @return the optional containing customer with the given id
+     */
+    Optional<Customer> getCustomer(int id);
+
+    /**
      * Returns true if a customer with the same identity as {@code customer} exists in the address book.
      */
     boolean hasPerson(Customer customer);

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -151,6 +151,11 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public Optional<Customer> getCustomer(int id) {
+        return this.addressBook.getById(id);
+    }
+
+    @Override
     public boolean hasPerson(Customer customer) {
         requireNonNull(customer);
         return addressBook.hasPerson(customer);

--- a/src/test/java/seedu/address/logic/commands/DeliveryAddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeliveryAddCommandTest.java
@@ -217,6 +217,11 @@ public class DeliveryAddCommandTest {
         }
 
         @Override
+        public Optional<Customer> getCustomer(int id) {
+            return Optional.empty();
+        }
+
+        @Override
         public boolean hasPerson(Customer customer) {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/seedu/address/logic/commands/customer/CustomerAddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/customer/CustomerAddCommandTest.java
@@ -167,6 +167,11 @@ public class CustomerAddCommandTest {
         }
 
         @Override
+        public Optional<Customer> getCustomer(int id) {
+            return Optional.empty();
+        }
+
+        @Override
         public boolean hasPerson(Customer customer) {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/seedu/address/logic/commands/customer/CustomerViewCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/customer/CustomerViewCommandTest.java
@@ -1,0 +1,83 @@
+package seedu.address.logic.commands.customer;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalDeliveries.getTypicalDeliveryBook;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.ClearCommand;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.person.Customer;
+
+public class CustomerViewCommandTest {
+
+    private Model model = new ModelManager(
+        getTypicalAddressBook(),
+        getTypicalDeliveryBook(),
+        new UserPrefs(),
+        true
+    );
+
+    @Test
+    public void execute_allFieldsValid_success() throws CommandException {
+        CustomerViewCommand customerViewCommand = new CustomerViewCommand(1);
+        Optional<Customer> customer = model.getCustomer(1);
+        String expectedMessage = Messages.format(customer.get());
+
+        assertCommandSuccess(customerViewCommand, model, expectedMessage, model);
+    }
+
+    @Test
+    public void execute_invalidTargetId_throwsCommandException() {
+        CustomerViewCommand customerViewCommand = new CustomerViewCommand(-1);
+        assertCommandFailure(customerViewCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void execute_allFieldsValidLoggedOut_throwsCommandException() {
+        model.setLogoutSuccess();
+        CustomerViewCommand customerViewCommand = new CustomerViewCommand(1);
+        assertCommandFailure(customerViewCommand, model, Messages.MESSAGE_USER_NOT_AUTHENTICATED);
+    }
+
+    @Test
+    public void execute_invalidTargetIdLoggedOut_throwsCommandException() {
+        model.setLogoutSuccess();
+        CustomerViewCommand customerViewCommand = new CustomerViewCommand(-1);
+        assertCommandFailure(customerViewCommand, model, Messages.MESSAGE_USER_NOT_AUTHENTICATED);
+    }
+
+    @Test
+    public void equals() {
+        CustomerViewCommand customerViewCommand = new CustomerViewCommand(1);
+        CustomerViewCommand customerViewCommandCopy = new CustomerViewCommand(1);
+        CustomerViewCommand customerViewCommandDifferent = new CustomerViewCommand(2);
+
+        // same object -> returns true
+        assertTrue(customerViewCommand.equals(customerViewCommand));
+
+        // null -> returns false
+        assertFalse(customerViewCommand.equals(null));
+
+        // different types -> returns false
+        assertFalse(customerViewCommand.equals(new ClearCommand()));
+
+        // same param -> returns true
+        assertTrue(customerViewCommand.equals(customerViewCommandCopy));
+
+        // different object -> returns false
+        assertFalse(customerViewCommand.equals(customerViewCommandDifferent));
+
+    }
+
+}

--- a/src/test/java/seedu/address/logic/commands/delivery/DeliveryFindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/delivery/DeliveryFindCommandTest.java
@@ -1,0 +1,105 @@
+package seedu.address.logic.commands.delivery;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.Messages.MESSAGE_DELIVERY_LISTED_OVERVIEW;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalDeliveries.GABRIELS_MILK;
+import static seedu.address.testutil.TypicalDeliveries.GAMBES_RICE;
+import static seedu.address.testutil.TypicalDeliveries.getTypicalDeliveryBook;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.Messages;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.delivery.DeliveryNameContainsKeywordsPredicate;
+
+public class DeliveryFindCommandTest {
+
+    private Model model = new ModelManager(getTypicalAddressBook(), getTypicalDeliveryBook(),
+        new UserPrefs(), true);
+    private Model expectedModel = new ModelManager(getTypicalAddressBook(), getTypicalDeliveryBook(),
+        new UserPrefs(), true);
+
+    @Test
+    public void equals() {
+        DeliveryNameContainsKeywordsPredicate firstPredicate =
+            new DeliveryNameContainsKeywordsPredicate(Collections.singletonList("first"));
+        DeliveryNameContainsKeywordsPredicate secondPredicate =
+            new DeliveryNameContainsKeywordsPredicate(Collections.singletonList("second"));
+
+        DeliveryFindCommand deliveryFindFirstCommand = new DeliveryFindCommand(firstPredicate);
+        DeliveryFindCommand deliveryFindSecondCommand = new DeliveryFindCommand(secondPredicate);
+
+        // same object -> returns true
+        assertTrue(deliveryFindFirstCommand.equals(deliveryFindFirstCommand));
+
+        // same values -> returns true
+        DeliveryFindCommand findFirstCommandCopy = new DeliveryFindCommand(firstPredicate);
+        assertTrue(deliveryFindFirstCommand.equals(findFirstCommandCopy));
+
+        // different types -> returns false
+        assertFalse(deliveryFindFirstCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(deliveryFindFirstCommand.equals(null));
+
+        // different query -> returns false
+        assertFalse(deliveryFindFirstCommand.equals(deliveryFindSecondCommand));
+    }
+
+    @Test
+    public void execute_zeroKeywords_noDeliveryFound() {
+        String expectedMessage = String.format(MESSAGE_DELIVERY_LISTED_OVERVIEW, 0);
+        DeliveryNameContainsKeywordsPredicate predicate = preparePredicate(" ");
+        DeliveryFindCommand command = new DeliveryFindCommand(predicate);
+        expectedModel.updateFilteredDeliveryList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel, true);
+        assertEquals(Collections.emptyList(), model.getFilteredDeliveryList());
+    }
+
+    @Test
+    public void execute_multipleKeywords_multipleDeliveriesFound() {
+        String expectedMessage = String.format(MESSAGE_DELIVERY_LISTED_OVERVIEW, 2);
+        DeliveryNameContainsKeywordsPredicate predicate = preparePredicate("Gabriel Gambe");
+        DeliveryFindCommand command = new DeliveryFindCommand(predicate);
+        expectedModel.updateFilteredDeliveryList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel, true);
+        assertEquals(Arrays.asList(GABRIELS_MILK, GAMBES_RICE), model.getFilteredDeliveryList());
+    }
+
+    @Test
+    public void execute_zeroKeywordsLoggedOut_failure() {
+        model.setLogoutSuccess();
+        expectedModel.setLogoutSuccess();
+        DeliveryNameContainsKeywordsPredicate predicate = preparePredicate(" ");
+        DeliveryFindCommand command = new DeliveryFindCommand(predicate);
+        expectedModel.updateFilteredDeliveryList(predicate);
+        assertCommandFailure(command, model, Messages.MESSAGE_USER_NOT_AUTHENTICATED);
+    }
+
+    @Test
+    public void execute_multipleKeywordsLoggedOut_failure() {
+        model.setLogoutSuccess();
+        expectedModel.setLogoutSuccess();
+        DeliveryNameContainsKeywordsPredicate predicate = preparePredicate("Kurz Elle Kunz");
+        DeliveryFindCommand command = new DeliveryFindCommand(predicate);
+        expectedModel.updateFilteredDeliveryList(predicate);
+        assertCommandFailure(command, model, Messages.MESSAGE_USER_NOT_AUTHENTICATED);
+    }
+
+    /**
+     * Parses {@code userInput} into a {@code DeliveryNameContainsKeywordsPredicate}.
+     */
+    private DeliveryNameContainsKeywordsPredicate preparePredicate(String userInput) {
+        return new DeliveryNameContainsKeywordsPredicate(Arrays.asList(userInput.split("\\s+")));
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -34,6 +34,7 @@ import seedu.address.logic.commands.delivery.DeliveryAddCommand;
 import seedu.address.logic.commands.delivery.DeliveryAddCommand.DeliveryAddDescriptor;
 import seedu.address.logic.commands.delivery.DeliveryCreateNoteCommand;
 import seedu.address.logic.commands.delivery.DeliveryDeleteCommand;
+import seedu.address.logic.commands.delivery.DeliveryFindCommand;
 import seedu.address.logic.commands.delivery.DeliveryStatusCommand;
 import seedu.address.logic.commands.delivery.DeliveryViewCommand;
 import seedu.address.logic.commands.user.UserLoginCommand;
@@ -41,6 +42,7 @@ import seedu.address.logic.commands.user.UserLogoutCommand;
 import seedu.address.logic.commands.user.UserRegisterCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.delivery.Delivery;
+import seedu.address.model.delivery.DeliveryNameContainsKeywordsPredicate;
 import seedu.address.model.delivery.DeliveryStatus;
 import seedu.address.model.delivery.Note;
 import seedu.address.model.person.Customer;
@@ -131,6 +133,16 @@ public class AddressBookParserTest {
 
 
     }
+
+    @Test
+    public void parseCommand_deliveryFind() throws Exception {
+        List<String> keywords = Arrays.asList("foo", "bar", "baz");
+        DeliveryFindCommand command = (DeliveryFindCommand) parser.parseCommand(
+            DeliveryFindCommand.COMMAND_WORD
+                + " " + keywords.stream().collect(Collectors.joining(" ")));
+        assertEquals(new DeliveryFindCommand(new DeliveryNameContainsKeywordsPredicate(keywords)), command);
+    }
+
     @Test
     public void parseCommand_exit() throws Exception {
         assertTrue(parser.parseCommand(ExitCommand.COMMAND_WORD) instanceof ExitCommand);

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -30,6 +30,7 @@ import seedu.address.logic.commands.customer.CustomerDeleteCommand;
 import seedu.address.logic.commands.customer.CustomerEditCommand;
 import seedu.address.logic.commands.customer.CustomerEditCommand.EditPersonDescriptor;
 import seedu.address.logic.commands.customer.CustomerListCommand;
+import seedu.address.logic.commands.customer.CustomerViewCommand;
 import seedu.address.logic.commands.delivery.DeliveryAddCommand;
 import seedu.address.logic.commands.delivery.DeliveryAddCommand.DeliveryAddDescriptor;
 import seedu.address.logic.commands.delivery.DeliveryCreateNoteCommand;
@@ -84,6 +85,14 @@ public class AddressBookParserTest {
                 CustomerDeleteCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased());
         assertEquals(new CustomerDeleteCommand(INDEX_FIRST_PERSON), command);
     }
+
+    @Test
+    public void parseCommand_customerView() throws Exception {
+        CustomerViewCommand command = (CustomerViewCommand) parser.parseCommand(
+            CustomerViewCommand.COMMAND_WORD + " " + VALID_VIEW_CUSTOMER_ID_1);
+        assertEquals(new CustomerViewCommand(Integer.parseInt(VALID_VIEW_CUSTOMER_ID_1)), command);
+    }
+
 
     @Test
     public void parseCommand_deliveryStatus() throws Exception {

--- a/src/test/java/seedu/address/logic/parser/customer/CustomerViewCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/customer/CustomerViewCommandParserTest.java
@@ -1,0 +1,55 @@
+package seedu.address.logic.parser.customer;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_VIEW_CUSTOMER_ID_1;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.customer.CustomerViewCommand;
+
+public class CustomerViewCommandParserTest {
+
+    private CustomerViewCommandParser parser = new CustomerViewCommandParser();
+
+    @Test
+    public void parse_emptyArg_throwsParseException() {
+        assertParseFailure(parser, "",
+            String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                CustomerViewCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_validArgs_returnsCustomerViewCommand() {
+        assertParseSuccess(parser, VALID_VIEW_CUSTOMER_ID_1,
+            new CustomerViewCommand(1));
+    }
+
+    @Test
+    public void parse_validArgsExtraSpaceBeforeAfter_returnsCustomerViewCommand() {
+        assertParseSuccess(parser, " " + VALID_VIEW_CUSTOMER_ID_1 + " ",
+            new CustomerViewCommand(1));
+    }
+
+    @Test
+    public void parse_invalidArgsNegative_throwsParseException() {
+        assertParseFailure(parser, "-1",
+            String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                CustomerViewCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_invalidArgsNaN_throwsParseException() {
+        assertParseFailure(parser, "a",
+            String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                CustomerViewCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_invalidArgsExtraNumber_throwsParseException() {
+        assertParseFailure(parser, "1 1",
+            String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                CustomerViewCommand.MESSAGE_USAGE));
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/delivery/DeliveryFindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/delivery/DeliveryFindCommandParserTest.java
@@ -1,0 +1,34 @@
+package seedu.address.logic.parser.delivery;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.delivery.DeliveryFindCommand;
+import seedu.address.model.delivery.DeliveryNameContainsKeywordsPredicate;
+
+public class DeliveryFindCommandParserTest {
+
+    private DeliveryFindCommandParser parser = new DeliveryFindCommandParser();
+
+    @Test
+    public void parse_emptyArg_throwsParseException() {
+        assertParseFailure(parser, "         ",
+            String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeliveryFindCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_validArgs_returnsDeliveryFindCommand() {
+        // no leading and trailing whitespaces
+        DeliveryFindCommand expectedFindCommand =
+            new DeliveryFindCommand(new DeliveryNameContainsKeywordsPredicate(Arrays.asList("Gabriel", "Gambe")));
+        assertParseSuccess(parser, "Gabriel Gambe", expectedFindCommand);
+
+        // multiple whitespaces between keywords
+        assertParseSuccess(parser, " \n Gabriel \n \t Gambe  \t", expectedFindCommand);
+    }
+}

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.model.delivery.Delivery;
 import seedu.address.model.delivery.DeliveryNameContainsKeywordsPredicate;
+import seedu.address.model.person.Customer;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.user.Password;
 import seedu.address.model.user.User;
@@ -84,6 +85,20 @@ public class ModelManagerTest {
     }
 
     @Test
+    public void getCustomer_validId_returnsOptionalCustomer() {
+        modelManager.addPerson(ALICE);
+        Optional<Customer> customer = modelManager.getCustomer(1);
+        assertEquals(customer.get(), ALICE);
+    }
+
+    @Test
+    public void getCustomer_invalidId_returnsEmptyOptional() {
+        modelManager.addPerson(ALICE);
+        Optional<Customer> customer = modelManager.getCustomer(0);
+        assertTrue(customer.isEmpty());
+    }
+
+    @Test
     public void hasPerson_nullPerson_throwsNullPointerException() {
         assertThrows(NullPointerException.class, () -> modelManager.hasPerson(null));
     }
@@ -115,6 +130,19 @@ public class ModelManagerTest {
         Path path = Paths.get("delivery/book/file/path");
         modelManager.setDeliveryBookFilePath(path);
         assertEquals(path, modelManager.getDeliveryBookFilePath());
+    }
+
+    @Test
+    public void getDelivery_validId_returnsOptionalDelivery() {
+        modelManager.addDelivery(GABRIELS_MILK);
+        Optional<Delivery> delivery = modelManager.getDelivery(1);
+        assertEquals(delivery.get(), GABRIELS_MILK);
+    }
+
+    @Test
+    public void getDelivery_invalidId_returnsEmptyOptional() {
+        Optional<Delivery> delivery = modelManager.getDelivery(0);
+        assertTrue(delivery.isEmpty());
     }
 
     @Test


### PR DESCRIPTION
In line with issue #12, added ability for user to view a specific `Customer`
using `CustomerViewCommand`. 

Following the Law of Demeter, Model has been modified to include an
additional method `getCustomer()` which will fetch the `Customer`
corresponding to the given `id` if it exists, and place it in an 

Fix DeliveryFindCommand which is is inheriting the `Command` class 
when it is supposed to be the `DeliveryCommand`.

Closes #12 .