### PR TITLE
Update DeliveryStatusCommand to set DeliveryDate

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -1702,6 +1702,7 @@ otherwise)
 **Guarantees:**
 
 - The status of the delivery is updated only if the command is executed successfully.
+- The delivery date of the delivery is updated only if the status is completed and the command is executed successfully.
 
 **MSS:**
 
@@ -1729,6 +1730,10 @@ otherwise)
     - 1c1. DMS informs the logged-in owner of an invalid delivery status being entered.
 
       Use case ends.
+
+- 1d. Logged-in owner specified the delivery status as completed.
+
+   - 1d1. DMS will update the DeliveryDate the specified delivery (if present) to the current date.
 
 ---
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -375,9 +375,12 @@ _STATUS:_ Either `CREATED`/`SHIPPED`/`COMPLETED`/`CANCELLED`
 
 _CUSTOMER_ID:_ Integer
 
+**The `DeliveryDate` of the specified delivery will be set to the current date if `STATUS` is `COMPLETED`*
+
 **Command succeeds:**
 
 ![Delivery Status](images/delivery/delivery_status.png)
+
 **Command fails (invalid_status):** _Delivery Status should be one of CREATED, SHIPPED, COMPLETED, CANCELLED_
 
 **Command fails (invalid_index):** _The delivery index provided is invalid_

--- a/src/main/java/seedu/address/logic/commands/delivery/DeliveryStatusCommand.java
+++ b/src/main/java/seedu/address/logic/commands/delivery/DeliveryStatusCommand.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.Messages.MESSAGE_USER_NOT_AUTHENTICATED;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_DELIVERIES;
 
+import java.time.LocalDate;
 import java.util.Optional;
 
 import seedu.address.commons.util.ToStringBuilder;
@@ -30,7 +31,7 @@ public class DeliveryStatusCommand extends DeliveryCommand {
             + "by the ID of the delivery. Existing status will be overwritten by the input status.\n"
             + "Parameters: ID (must be a integer representing a valid ID) "
             + "STATUS (must be one of CREATED/SHIPPED/COMPLETED/CANCELLED)\n"
-            + "Example: " + COMMAND_WORD + " COMPLETED 1";
+            + "Example: " + COMMAND_WORD + " 1 COMPLETED";
 
     public static final String MESSAGE_EDIT_DELIVERY_SUCCESS = "Edited Delivery: %1$s";
 
@@ -51,6 +52,7 @@ public class DeliveryStatusCommand extends DeliveryCommand {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
+
         // User cannot perform this operation before logging in
         if (!model.getUserLoginStatus()) {
             throw new CommandException(MESSAGE_USER_NOT_AUTHENTICATED);
@@ -59,6 +61,7 @@ public class DeliveryStatusCommand extends DeliveryCommand {
         // Find Delivery
         Optional<Delivery> targetDelivery = model.getDelivery(targetId);
 
+        // Delivery ID must match a valid delivery
         if (targetDelivery.isEmpty()) {
             throw new CommandException(Messages.MESSAGE_INVALID_DELIVERY_DISPLAYED_INDEX);
         }
@@ -83,9 +86,17 @@ public class DeliveryStatusCommand extends DeliveryCommand {
         DeliveryName updatedName = deliveryToEdit.getName();
         Customer updatedCustomer = deliveryToEdit.getCustomer();
         OrderDate updatedOrderDate = deliveryToEdit.getOrderDate();
-        DeliveryDate updatedDeliveryDate = deliveryToEdit.getDeliveryDate();
         DeliveryStatus updatedStatus = newStatus;
         Note updatedNote = deliveryToEdit.getNote();
+
+        // If set to completed
+        // bring forward delivery date
+        DeliveryDate updatedDeliveryDate;
+        if (updatedStatus == DeliveryStatus.COMPLETED) {
+            updatedDeliveryDate = new DeliveryDate(LocalDate.now());
+        } else {
+            updatedDeliveryDate = deliveryToEdit.getDeliveryDate();
+        }
 
 
         return new Delivery(updatedId, updatedName, updatedCustomer, updatedOrderDate,

--- a/src/main/java/seedu/address/model/delivery/Date.java
+++ b/src/main/java/seedu/address/model/delivery/Date.java
@@ -18,7 +18,7 @@ public class Date implements Comparable<Date> {
     public final LocalDate date;
 
     /**
-     * Constructs a {@code DeliveryDate}.
+     * Constructs a {@code Date}.
      *
      * @param date A valid date.
      */
@@ -26,6 +26,16 @@ public class Date implements Comparable<Date> {
         requireNonNull(date);
         checkArgument(isValidDate(date), MESSAGE_CONSTRAINTS);
         this.date = LocalDate.parse(date);
+    }
+
+    /**
+     * Constructs a {@code Date}.
+     *
+     * @param date A valid {@code LocalDate}.
+     */
+    protected Date(LocalDate date) {
+        requireNonNull(date);
+        this.date = date;
     }
 
     /**

--- a/src/main/java/seedu/address/model/delivery/DeliveryDate.java
+++ b/src/main/java/seedu/address/model/delivery/DeliveryDate.java
@@ -18,6 +18,15 @@ public class DeliveryDate extends Date {
     }
 
     /**
+     * Constructs a {@code DeliveryDate}.
+     *
+     * @param date A valid {@code LocalDate}.
+     */
+    public DeliveryDate(LocalDate date) {
+        super(date);
+    }
+
+    /**
      * Returns true if a given string is a valid delivery date.
      *
      * @param date A string representing a date.

--- a/src/test/java/seedu/address/logic/commands/delivery/DeliveryStatusCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/delivery/DeliveryStatusCommandTest.java
@@ -10,6 +10,8 @@ import static seedu.address.testutil.TypicalDeliveries.GAMBES_RICE;
 import static seedu.address.testutil.TypicalDeliveries.getTypicalDeliveryBook;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
+import java.time.LocalDate;
+
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.Messages;
@@ -28,8 +30,29 @@ public class DeliveryStatusCommandTest {
 
     @Test
     public void execute_allFieldsValid_success() {
-        DeliveryStatus deliveryStatus = DeliveryStatus.COMPLETED;
+        DeliveryStatus deliveryStatus = DeliveryStatus.SHIPPED;
         Delivery expectedDelivery = new DeliveryBuilder(GABRIELS_MILK).withStatus(deliveryStatus).build();
+        DeliveryStatusCommand deliveryStatusCommand =
+            new DeliveryStatusCommand(GABRIELS_MILK.getDeliveryId(), deliveryStatus);
+
+        String expectedMessage = String.format(DeliveryStatusCommand.MESSAGE_EDIT_DELIVERY_SUCCESS,
+            Messages.format(expectedDelivery));
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()),
+            new DeliveryBook(model.getDeliveryBook()),
+            new UserPrefs(),
+            true);
+        expectedModel.setDelivery(model.getDeliveryBook().getById(GABRIELS_MILK.getDeliveryId()).get(),
+            expectedDelivery);
+
+        assertCommandSuccess(deliveryStatusCommand, model, expectedMessage, expectedModel, true);
+    }
+
+    @Test
+    public void execute_completedStatusShouldUpdateDeliveryDate_success() {
+        DeliveryStatus deliveryStatus = DeliveryStatus.COMPLETED;
+        Delivery expectedDelivery =
+            new DeliveryBuilder(GABRIELS_MILK).withStatus(deliveryStatus).withDeliveryDate(LocalDate.now()).build();
         DeliveryStatusCommand deliveryStatusCommand =
             new DeliveryStatusCommand(GABRIELS_MILK.getDeliveryId(), deliveryStatus);
 

--- a/src/test/java/seedu/address/model/delivery/DateTest.java
+++ b/src/test/java/seedu/address/model/delivery/DateTest.java
@@ -1,22 +1,41 @@
 package seedu.address.model.delivery;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
+
+import java.time.LocalDate;
 
 import org.junit.jupiter.api.Test;
 
 public class DateTest {
 
     @Test
-    public void constructor_null_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> new Date(null));
+    public void stringConstructor_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new Date((String) null));
+    }
+
+    @Test
+    public void localDateConstructor_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new Date((LocalDate) null));
     }
 
     @Test
     public void constructor_invalidDate_throwsIllegalArgumentException() {
         String invalidDate = "";
         assertThrows(IllegalArgumentException.class, () -> new Date(invalidDate));
+    }
+
+    @Test
+    public void constructor_validDateString_success() {
+        String validDate = "2023-12-12";
+        assertDoesNotThrow(() -> new Date(validDate));
+    }
+
+    @Test
+    public void constructor_validDateLocalDate_success() {
+        assertDoesNotThrow(() -> new Date(LocalDate.now()));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/delivery/DeliveryDateTest.java
+++ b/src/test/java/seedu/address/model/delivery/DeliveryDateTest.java
@@ -1,10 +1,12 @@
 package seedu.address.model.delivery;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
 
 import java.time.DateTimeException;
+import java.time.LocalDate;
 
 import org.junit.jupiter.api.Test;
 
@@ -12,14 +14,30 @@ import org.junit.jupiter.api.Test;
 public class DeliveryDateTest {
 
     @Test
-    public void constructor_null_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> new DeliveryDate(null));
+    public void stringConstructor_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new DeliveryDate((String) null));
+    }
+
+    @Test
+    public void localDateConstructor_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new DeliveryDate((LocalDate) null));
     }
 
     @Test
     public void constructor_invalidDate_throwsIllegalArgumentException() {
         String invalidDate = "";
         assertThrows(IllegalArgumentException.class, () -> new DeliveryDate(invalidDate));
+    }
+
+    @Test
+    public void constructor_validDateString_success() {
+        String validDate = "2023-12-12";
+        assertDoesNotThrow(() -> new DeliveryDate(validDate));
+    }
+
+    @Test
+    public void constructor_validDateLocalDate_success() {
+        assertDoesNotThrow(() -> new DeliveryDate(LocalDate.now()));
     }
 
     @Test

--- a/src/test/java/seedu/address/testutil/DeliveryBuilder.java
+++ b/src/test/java/seedu/address/testutil/DeliveryBuilder.java
@@ -125,6 +125,17 @@ public class DeliveryBuilder {
     }
 
     /**
+     * Sets the {@code deliveredAt} of the {@code Delivery} that we are building.
+     *
+     * @param deliveryDate The deliveredAt to set.
+     * @return The DeliveryBuilder with the deliveredAt set.
+     */
+    public DeliveryBuilder withDeliveryDate(LocalDate deliveryDate) {
+        this.deliveredAt = new DeliveryDate(deliveryDate);
+        return this;
+    }
+
+    /**
      * Sets the {@code status} of the {@code Delivery} that we are building.
      *
      * @param status The status to set.


### PR DESCRIPTION
As the DeliveryDate should be updated whe the DeliveryStatus is set to `COMPLETED`, the DeliveryStatusCommand has been updated so that it will set the DeliveryDate of the specified Delivery to `now()` when the DeliveryStatus is set to `COMPLETED`.

Fix DeliveryStatusCommand example formatting in line with current command format.

Closes #239 
Closes #240