### PR TITLE
Fix right click bug

### DIFF
--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -160,7 +160,6 @@
 
 .result-display .label {
     -fx-text-fill: black !important;
-    -fx-background-color: black;
 }
 
 .status-bar .label {
@@ -195,7 +194,7 @@
 }
 
 .context-menu .label {
-    -fx-text-fill: white;
+    -fx-text-fill: black;
 }
 
 .menu-bar {


### PR DESCRIPTION
Closes #262 

Set the right-click context menu label text color to black
Set the right-click context menu label text to not have background color