### PR TITLE
Fix bugs related to user

### DIFF
--- a/src/main/java/seedu/address/logic/commands/user/UserRecoverAccountCommand.java
+++ b/src/main/java/seedu/address/logic/commands/user/UserRecoverAccountCommand.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ANSWER;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PASSWORD;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PASSWORD_CONFIRM;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_CUSTOMERS;
 
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CommandResult;
@@ -89,7 +90,8 @@ public class UserRecoverAccountCommand extends Command {
         User newUser = new User(storedUser.getUsername(), newPassword, true,
                 storedUser.getSecretQuestion(), storedUser.getAnswer());
         model.resetPassword(newUser);
-        return new CommandResult(MESSAGE_SUCCESS_WITH_FLAGS);
+        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_CUSTOMERS);
+        return new CommandResult(MESSAGE_SUCCESS_WITH_FLAGS, true);
     }
 
     public boolean isShowSecretQuestion() {

--- a/src/main/java/seedu/address/logic/commands/user/UserUpdateCommand.java
+++ b/src/main/java/seedu/address/logic/commands/user/UserUpdateCommand.java
@@ -33,7 +33,7 @@ public class UserUpdateCommand extends Command {
             + "[" + PREFIX_USER + " USERNAME] "
             + "[" + PREFIX_PASSWORD + " PASSWORD "
             + PREFIX_PASSWORD_CONFIRM + " CONFIRM_PASSWORD] "
-            + "[" + PREFIX_SECRET_QUESTION + " SECRET_PASSWORD "
+            + "[" + PREFIX_SECRET_QUESTION + " SECRET_QUESTION "
             + PREFIX_ANSWER + " ANSWER]\n"
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_PASSWORD + " yourNewPassword "

--- a/src/main/java/seedu/address/logic/parser/user/UserUpdateCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/user/UserUpdateCommandParser.java
@@ -7,7 +7,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_PASSWORD_CONFIRM;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SECRET_QUESTION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_USER;
 
-import seedu.address.logic.commands.customer.CustomerAddCommand;
 import seedu.address.logic.commands.user.UserUpdateCommand;
 import seedu.address.logic.commands.user.UserUpdateCommand.UserUpdateDescriptor;
 import seedu.address.logic.parser.ArgumentMultimap;

--- a/src/main/java/seedu/address/logic/parser/user/UserUpdateCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/user/UserUpdateCommandParser.java
@@ -1,11 +1,13 @@
 package seedu.address.logic.parser.user;
 
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ANSWER;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PASSWORD;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PASSWORD_CONFIRM;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SECRET_QUESTION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_USER;
 
+import seedu.address.logic.commands.customer.CustomerAddCommand;
 import seedu.address.logic.commands.user.UserUpdateCommand;
 import seedu.address.logic.commands.user.UserUpdateCommand.UserUpdateDescriptor;
 import seedu.address.logic.parser.ArgumentMultimap;
@@ -34,6 +36,10 @@ public class UserUpdateCommandParser implements Parser<UserUpdateCommand> {
                 PREFIX_SECRET_QUESTION, PREFIX_ANSWER);
 
         UserUpdateDescriptor userUpdateDescriptor = new UserUpdateDescriptor();
+
+        if (!argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, UserUpdateCommand.MESSAGE_USAGE));
+        }
 
         if (argMultimap.getValue(PREFIX_USER).isPresent()) {
             userUpdateDescriptor.setUsername(ParserUtil.parseUsername(argMultimap.getValue(PREFIX_USER).get()));

--- a/src/test/java/seedu/address/logic/parser/user/UserUpdateCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/user/UserUpdateCommandParserTest.java
@@ -1,5 +1,6 @@
 package seedu.address.logic.parser.user;
 
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.commands.CommandTestUtil.ANSWER_DESC_AARON;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_PASSWORD_CONFIRM_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_PASSWORD_DESC;
@@ -7,6 +8,7 @@ import static seedu.address.logic.commands.CommandTestUtil.INVALID_USERNAME_DESC
 import static seedu.address.logic.commands.CommandTestUtil.PASSWORD_CONFIRM_DESC_AARON;
 import static seedu.address.logic.commands.CommandTestUtil.PASSWORD_CONFIRM_DESC_FOODBEAR;
 import static seedu.address.logic.commands.CommandTestUtil.PASSWORD_DESC_AARON;
+import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_NON_EMPTY;
 import static seedu.address.logic.commands.CommandTestUtil.SECRET_QUESTION_DESC_AARON;
 import static seedu.address.logic.commands.CommandTestUtil.USERNAME_DESC_AARON;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ANSWER_AARON;
@@ -92,6 +94,10 @@ public class UserUpdateCommandParserTest {
         // multiple invalid values, but only the first invalid value is captured
         assertParseFailure(parser, INVALID_USERNAME_DESC + INVALID_PASSWORD_DESC
                         + INVALID_PASSWORD_CONFIRM_DESC, Username.MESSAGE_CONSTRAINTS);
+
+        // non-empty preamble
+        assertParseFailure(parser, PREAMBLE_NON_EMPTY + USERNAME_DESC_AARON,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, UserUpdateCommand.MESSAGE_USAGE));
     }
 
     @Test


### PR DESCRIPTION
Closes #316 

List should be shown after account recovered
Update account should not allow non-empty preamble
Update account secret question displays wrong parameter name