### PR TITLE
Update Note to not allow non-alphanumeric strings

### DIFF
--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -168,7 +168,7 @@ public class ParserUtil {
     public static Note parseNote(String note) throws ParseException {
         requireNonNull(note);
         String trimmedNote = note.trim();
-        if (!Note.isNotEmpty(trimmedNote)) {
+        if (!Note.isValid(trimmedNote)) {
             throw new ParseException(Note.MESSAGE_CONSTRAINTS);
         }
         return new Note(trimmedNote);

--- a/src/main/java/seedu/address/model/delivery/Note.java
+++ b/src/main/java/seedu/address/model/delivery/Note.java
@@ -9,7 +9,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class Note {
 
     public static final String MESSAGE_CONSTRAINTS =
-        "Note should not be empty";
+        "Note should not be a non-empty alphanumeric string";
     public final String note;
 
     /**
@@ -19,7 +19,7 @@ public class Note {
      */
     public Note(String note) {
         requireNonNull(note);
-        checkArgument(isNotEmpty(note), MESSAGE_CONSTRAINTS);
+        checkArgument(isValid(note), MESSAGE_CONSTRAINTS);
         this.note = note;
     }
 
@@ -39,7 +39,7 @@ public class Note {
             && note.equals(((Note) other).note)); // state check
     }
 
-    public static boolean isNotEmpty(String test) {
-        return !test.isEmpty();
+    public static boolean isValid(String test) {
+        return !test.isEmpty() && test.matches("^[A-Za-z0-9\\s]+$");
     }
 }

--- a/src/main/java/seedu/address/storage/JsonAdaptedDelivery.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedDelivery.java
@@ -135,7 +135,7 @@ class JsonAdaptedDelivery {
 
         final Note modelNote;
         if (note != null) {
-            if (!Note.isNotEmpty(note)) {
+            if (!Note.isValid(note)) {
                 throw new IllegalValueException(Note.MESSAGE_CONSTRAINTS);
             }
             modelNote = new Note(note);

--- a/src/test/java/seedu/address/model/delivery/DeliveryTest.java
+++ b/src/test/java/seedu/address/model/delivery/DeliveryTest.java
@@ -62,7 +62,7 @@ public class DeliveryTest {
     @Test
     public void setNote() {
         Delivery delivery = new DeliveryBuilder().autoBuild();
-        Note note = new Note("Hi!");
+        Note note = new Note("Hi");
         delivery.setNote(note);
         assertTrue(delivery.getNote().equals(note));
     }

--- a/src/test/java/seedu/address/model/delivery/NoteTest.java
+++ b/src/test/java/seedu/address/model/delivery/NoteTest.java
@@ -19,15 +19,40 @@ public class NoteTest {
     }
 
     @Test
-    public void isNotEmpty() {
+    public void isValid() {
         // null name
-        assertThrows(NullPointerException.class, () -> Note.isNotEmpty(null));
+        assertThrows(NullPointerException.class, () -> Note.isValid(null));
 
-        // invalid note
-        assertFalse(Note.isNotEmpty("")); // empty string
+        // invalid note -> returns false
+        assertFalse(Note.isValid("")); // empty string
 
-        // valid name
-        assertTrue(Note.isNotEmpty("peter jack")); // alphabets only
+        // valid note -> returns false
+        assertTrue(Note.isValid("peter jack")); // alphabets only
+
+        // valid note -> returns false
+        assertTrue(Note.isValid("az 09")); // alphanumeric
+
+        // valid note -> returns false
+        assertTrue(Note.isValid("AZ 123")); // alphanumeric with capital letters
+
+        // invalid note -> returns false
+        assertFalse(Note.isValid("@")); // includes special characters, boundary of ASCII A
+
+        // invalid note -> returns false
+        assertFalse(Note.isValid("[")); // includes special characters, boundary of ASCII Z
+
+        // invalid note -> returns false
+        assertFalse(Note.isValid("`")); // includes special characters, boundary of ASCII a
+
+        // invalid note -> returns false
+        assertFalse(Note.isValid("{")); // includes special characters, boundary of ASCII z
+
+        // invalid note -> returns false
+        assertFalse(Note.isValid("/")); // includes special characters, boundary of ASCII 0
+
+        // invalid note -> returns false
+        assertFalse(Note.isValid(":")); // includes special characters, boundary of ASCII 9
+
     }
 
     @Test


### PR DESCRIPTION
Refactor Note#isEmpty() to Note#isValid() to check for non-empty alphanumeric strings.

Closes #324.