### PR TITLE
Modify Predicate to create defensive copy

### DIFF
--- a/src/main/java/seedu/address/model/delivery/DeliveryNameContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/delivery/DeliveryNameContainsKeywordsPredicate.java
@@ -12,8 +12,13 @@ import seedu.address.commons.util.ToStringBuilder;
 public class DeliveryNameContainsKeywordsPredicate implements Predicate<Delivery> {
     private final List<String> keywords;
 
+    /**
+     * Creates a DeliveryNameContainsKeywordsPredicate.
+     * @param keywords the list of keywords to search for.
+     */
     public DeliveryNameContainsKeywordsPredicate(List<String> keywords) {
-        this.keywords = keywords;
+        // Create Defensive Copy to prevent modification
+        this.keywords = List.copyOf(keywords);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/NameContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/NameContainsKeywordsPredicate.java
@@ -12,8 +12,13 @@ import seedu.address.commons.util.ToStringBuilder;
 public class NameContainsKeywordsPredicate implements Predicate<Customer> {
     private final List<String> keywords;
 
+    /**
+     * Creates a NameContainsKeywordsPredicate.
+     * @param keywords the list of keywords to search for.
+     */
     public NameContainsKeywordsPredicate(List<String> keywords) {
-        this.keywords = keywords;
+        // Create Defensive Copy to prevent modification
+        this.keywords = List.copyOf(keywords);
     }
 
     @Override

--- a/src/test/java/seedu/address/model/delivery/DeliveryNameContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/delivery/DeliveryNameContainsKeywordsPredicateTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.TypicalPersons.ALICE;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -14,6 +15,17 @@ import org.junit.jupiter.api.Test;
 import seedu.address.testutil.DeliveryBuilder;
 
 public class DeliveryNameContainsKeywordsPredicateTest {
+
+    @Test
+    public void constructor_createsImmutableList() {
+        ArrayList<String> predicateKeywordList = new ArrayList<>();
+        predicateKeywordList.add("shouldBeHere");
+        DeliveryNameContainsKeywordsPredicate deliveryNameContainsKeywordsPredicate =
+            new DeliveryNameContainsKeywordsPredicate(predicateKeywordList);
+        predicateKeywordList.clear();
+        assertEquals(deliveryNameContainsKeywordsPredicate.toString(),
+            DeliveryNameContainsKeywordsPredicate.class.getCanonicalName() + "{keywords=[shouldBeHere]}");
+    }
 
     @Test
     public void equals() {

--- a/src/test/java/seedu/address/model/person/NameContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/NameContainsKeywordsPredicateTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -13,6 +14,17 @@ import org.junit.jupiter.api.Test;
 import seedu.address.testutil.CustomerBuilder;
 
 public class NameContainsKeywordsPredicateTest {
+
+    @Test
+    public void constructor_createsImmutableList() {
+        ArrayList<String> predicateKeywordList = new ArrayList<>();
+        predicateKeywordList.add("shouldBeHere");
+        NameContainsKeywordsPredicate nameContainsKeywordsPredicate =
+            new NameContainsKeywordsPredicate(predicateKeywordList);
+        predicateKeywordList.clear();
+        assertEquals(nameContainsKeywordsPredicate.toString(),
+            NameContainsKeywordsPredicate.class.getCanonicalName() + "{keywords=[shouldBeHere]}");
+    }
 
     @Test
     public void equals() {


### PR DESCRIPTION
To prevent predicate keywords from being modified unintentionally.

Closes #335.