### PR TITLE
Remove ALL from being a valid Status

### DIFF
--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -192,10 +192,6 @@ public class ParserUtil {
         requireNonNull(status);
         String trimmedStatus = status.trim().toUpperCase();
 
-        if (trimmedStatus.equals("ALL")) {
-            return null;
-        }
-
         if (!DeliveryStatus.isValidStatus(trimmedStatus)) {
             throw new ParseException(DeliveryStatus.MESSAGE_CONSTRAINTS);
         }

--- a/src/main/java/seedu/address/logic/parser/delivery/DeliveryStatusCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/delivery/DeliveryStatusCommandParser.java
@@ -41,10 +41,7 @@ public class DeliveryStatusCommandParser implements Parser<DeliveryStatusCommand
         final String id = matcher.group("id");
 
         DeliveryStatus deliveryStatus = ParserUtil.parseDeliveryStatus(status);
-        if (deliveryStatus == null) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                DeliveryStatusCommand.MESSAGE_USAGE));
-        }
+
         int deliveryId = ParserUtil.parseId(id);
 
         return new DeliveryStatusCommand(deliveryId, deliveryStatus);

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -163,7 +163,6 @@ public class CommandTestUtil {
     public static final String PREAMBLE_WHITESPACE = "\t  \r  \n";
     public static final String PREAMBLE_NON_EMPTY = "NonEmptyPreamble";
 
-    public static final String VALID_DELIVERY_LIST_ALL = " " + PREFIX_STATUS + "all";
     public static final String INVALID_DELIVERY_LIST_ALL = " " + "sadasdasdasdasdasdas";
     public static final String VALID_DELIVERY_LIST_CUSTOMER_ID = " " + PREFIX_CUSTOMER_ID + "1";
     public static final String INVALID_DELIVERY_LIST_CUSTOMER_ID = " " + PREFIX_CUSTOMER_ID + "x";

--- a/src/test/java/seedu/address/logic/parser/delivery/DeliveryListParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/delivery/DeliveryListParserTest.java
@@ -7,7 +7,6 @@ import static seedu.address.logic.commands.CommandTestUtil.INVALID_DELIVERY_LIST
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_DELIVERY_LIST_DELIVERY_DATE_MONTH;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_DELIVERY_LIST_DELIVERY_DATE_TODAY;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_DELIVERY_LIST_SORT;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_DELIVERY_LIST_ALL;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_DELIVERY_LIST_CANCELLED;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_DELIVERY_LIST_COMPLETED;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_DELIVERY_LIST_CREATED;
@@ -40,8 +39,6 @@ public class DeliveryListParserTest {
     @Test
     public void parse_validArgs_returnsDeliveryListCommand() {
 
-        CommandParserTestUtil.assertParseSuccess(parser, VALID_DELIVERY_LIST_ALL,
-            new DeliveryListCommand(null, null, null, Sort.DESC));
         CommandParserTestUtil.assertParseSuccess(parser, VALID_DELIVERY_LIST_SHIPPED,
             new DeliveryListCommand(DeliveryStatus.SHIPPED, null, null, Sort.DESC));
         CommandParserTestUtil.assertParseSuccess(parser, VALID_DELIVERY_LIST_CREATED,
@@ -53,26 +50,25 @@ public class DeliveryListParserTest {
             new DeliveryListCommand(DeliveryStatus.CANCELLED, null, null, Sort.DESC));
 
         // Test customerId
-        CommandParserTestUtil.assertParseSuccess(parser, VALID_DELIVERY_LIST_ALL + VALID_DELIVERY_LIST_CUSTOMER_ID,
+        CommandParserTestUtil.assertParseSuccess(parser, VALID_DELIVERY_LIST_CUSTOMER_ID,
             new DeliveryListCommand(null, 1, null, Sort.DESC));
 
         // Test deliveryDate
-        CommandParserTestUtil.assertParseSuccess(parser, VALID_DELIVERY_LIST_ALL + VALID_DELIVERY_LIST_DELIVERY_DATE,
+        CommandParserTestUtil.assertParseSuccess(parser, VALID_DELIVERY_LIST_DELIVERY_DATE,
             new DeliveryListCommand(null, null, new Date("2023-12-12"),
                 Sort.DESC));
 
         // Test delivery date if "today"
         CommandParserTestUtil.assertParseSuccess(parser,
-            VALID_DELIVERY_LIST_ALL + " "
-                + VALID_DELIVERY_LIST_DELIVERY_DATE_TODAY,
+            VALID_DELIVERY_LIST_DELIVERY_DATE_TODAY,
             new DeliveryListCommand(null, null,
                 new Date(LocalDate.now().format(DateTimeFormatter.ofPattern(Date.FORMAT))),
                 Sort.DESC));
 
-        CommandParserTestUtil.assertParseSuccess(parser, VALID_DELIVERY_LIST_ALL + VALID_DELIVERY_LIST_SORT_ASC,
+        CommandParserTestUtil.assertParseSuccess(parser, VALID_DELIVERY_LIST_SORT_ASC,
             new DeliveryListCommand(null, null, null, Sort.ASC));
 
-        CommandParserTestUtil.assertParseSuccess(parser, VALID_DELIVERY_LIST_ALL + VALID_DELIVERY_LIST_SORT_DESC,
+        CommandParserTestUtil.assertParseSuccess(parser, VALID_DELIVERY_LIST_SORT_DESC,
             new DeliveryListCommand(null, null, null, Sort.DESC));
 
 
@@ -99,10 +95,10 @@ public class DeliveryListParserTest {
 
     @Test
     public void execute_listIsFilteredByWrongDate_throwsParseException() {
-        CommandParserTestUtil.assertParseFailure(parser, VALID_DELIVERY_LIST_ALL + INVALID_DELIVERY_LIST_DELIVERY_DATE,
+        CommandParserTestUtil.assertParseFailure(parser, INVALID_DELIVERY_LIST_DELIVERY_DATE,
             String.format(Date.MESSAGE_CONSTRAINTS));
         CommandParserTestUtil.assertParseFailure(parser,
-            VALID_DELIVERY_LIST_ALL + INVALID_DELIVERY_LIST_DELIVERY_DATE_MONTH,
+            INVALID_DELIVERY_LIST_DELIVERY_DATE_MONTH,
             String.format(Date.MESSAGE_CONSTRAINTS));
     }
 

--- a/src/test/java/seedu/address/logic/parser/delivery/DeliveryStatusCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/delivery/DeliveryStatusCommandParserTest.java
@@ -86,7 +86,7 @@ public class DeliveryStatusCommandParserTest {
 
     @Test
     public void parse_invalidAllStatus_failure() {
-        assertParseFailure(parser, "1 ALL", MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, "1 ALL", DeliveryStatus.MESSAGE_CONSTRAINTS);
     }
 
     @Test


### PR DESCRIPTION
Previously ALL was a valid Status for Delivery List, however that option has since deprecated 
and is being removed to simplify valid status checking.

Closes #346.