### PR TITLE
Cleanup ModelManager

### DIFF
--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -141,6 +141,26 @@ public interface Model {
     void updateFilteredCustomerList(Predicate<Customer> predicate);
 
     /**
+     * Resets the customer list to all customers.
+     */
+    void showAllFilteredCustomerList();
+
+    /**
+     * Returns the number of customers in the filtered customer list.
+     *
+     * @return the number of customers in the filtered customer list.
+     */
+    int getFilteredCustomerListSize();
+
+    /**
+     * Returns true if the filtered customer list is empty.
+     *
+     * @return true if the filtered customer list is empty.
+     */
+    boolean isFilteredCustomerListEmpty();
+
+
+    /**
      * Returns the user prefs' delivery book file path.
      */
     Path getDeliveryBookFilePath();
@@ -201,12 +221,39 @@ public interface Model {
     void setDelivery(Delivery target, Delivery editedDelivery);
 
     /**
+     * Resets the delivery list to show all deliveries.
+     */
+    void showAllFilteredDeliveryList();
+
+    /**
+     * Returns the number of deliveries in the filtered delivery list.
+     *
+     * @return the number of deliveries in the filtered delivery list.
+     */
+    int getFilteredDeliveryListSize();
+
+    /**
+     * Returns true if the filtered delivery list is empty.
+     *
+     * @return true if the filtered delivery list is empty.
+     */
+    boolean isFilteredDeliveryListEmpty();
+
+    /**
+     * Returns the number of deliveries in the sorted delivery list.
+     *
+     * @return the number of deliveries in the sorted delivery list.
+     */
+    boolean isSortedDeliveryListEmpty();
+
+    /**
      * Returns an unmodifiable view of the filtered delivery list
      */
     ObservableList<Delivery> getFilteredDeliveryList();
 
     ObservableList<Delivery> getSortedDeliveryList();
 
+    @Deprecated
     Delivery getDeliveryUsingFilteredList(int id);
 
     /**

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -526,7 +526,6 @@ public class ModelManager implements Model {
 
         // only shows the delivery list if the user is logged in
         filteredDeliveries.setPredicate(predicate);
-        
         // Update the sorted list
         this.sortedDeliveries = new SortedList<>(filteredDeliveries);
 

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -519,13 +519,14 @@ public class ModelManager implements Model {
     @Override
     public void updateFilteredDeliveryList(Predicate<Delivery> predicate) {
         requireNonNull(predicate);
-        // only shows the delivery list if the user is logged in
-        if (isLoggedIn) {
-            filteredDeliveries.setPredicate(predicate);
-        } else {
+        if (!isLoggedIn) {
             filteredDeliveries.setPredicate(PREDICATE_SHOW_NO_DELIVERIES);
+            return;
         }
 
+        // only shows the delivery list if the user is logged in
+        filteredDeliveries.setPredicate(predicate);
+        
         // Update the sorted list
         this.sortedDeliveries = new SortedList<>(filteredDeliveries);
 

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -34,8 +34,8 @@ public class ModelManager implements Model {
 
     private final FilteredList<Customer> filteredCustomers;
     private final FilteredList<Delivery> filteredDeliveries;
-    private User loggedInUser;
     private SortedList<Delivery> sortedDeliveries;
+    private User loggedInUser;
 
     private ObservableList<ListItem> uiList;
 
@@ -54,13 +54,14 @@ public class ModelManager implements Model {
         this.addressBook = new AddressBook(addressBook);
         this.deliveryBook = new DeliveryBook(deliveryBook);
         this.userPrefs = new UserPrefs(userPrefs);
-        filteredCustomers = new FilteredList<>(this.addressBook.getList());
-        filteredDeliveries = new FilteredList<>(this.deliveryBook.getList());
-        sortedDeliveries = new SortedList<>(filteredDeliveries);
+        this.filteredCustomers = new FilteredList<>(this.addressBook.getList());
+        this.filteredDeliveries = new FilteredList<>(this.deliveryBook.getList());
+        this.sortedDeliveries = new SortedList<>(filteredDeliveries);
         this.isLoggedIn = isLoggedIn;
         this.loggedInUser = userPrefs.getStoredUser();
-        this.setUiListCustomer();
 
+        // Set the UI list to the customer list by default
+        this.setUiListCustomer();
     }
 
     public ModelManager() {
@@ -94,31 +95,35 @@ public class ModelManager implements Model {
 
     @Override
     public void setUiListDelivery() {
-        String orderDateFormat = "Ordered on: %s";
-        String deliveryDateFormat = "Deliver by: %s";
-        this.uiList = this.getSortedDeliveryList().stream().map(
-                delivery -> new ListItem(String.format("[%d] %s",
-                    delivery.getDeliveryId(),
-                    delivery.getName()),
-                    String.format(orderDateFormat,
-                        delivery.getOrderDate().toString()),
-                    delivery.getStatus().toString(),
-                    String.format(deliveryDateFormat, delivery.getDeliveryDate().toString())))
-            .collect(Collectors.toCollection(
-                FXCollections::observableArrayList));
+        this.uiList = this.getSortedDeliveryList()
+            .stream()
+            .map(this::transformDeliveryToListItem)
+            .collect(Collectors.toCollection(FXCollections::observableArrayList));
+    }
+
+    private ListItem transformDeliveryToListItem(Delivery delivery) {
+        return new ListItem(String.format("[%d] %s", delivery.getDeliveryId(), delivery.getName()),
+            String.format("Ordered on: %s", delivery.getOrderDate().toString()),
+            delivery.getStatus().toString(),
+            String.format("Deliver by: %s", delivery.getDeliveryDate().toString()));
     }
 
 
     @Override
     public void setUiListCustomer() {
-        String descriptionFormat = "Email: %s\nAddress: %s";
-        this.uiList = this.getFilteredCustomerList().stream().map(
-                customer -> new ListItem(String.format("[%d] %s", customer.getCustomerId(), customer.getName()),
-                    String.format(descriptionFormat,
-                        customer.getEmail().toString(),
-                        customer.getAddress().toString()),
-                    customer.getPhone().toString()))
+        this.uiList = this.getFilteredCustomerList()
+            .stream()
+            .map(this::transformCustomerToListItem)
             .collect(Collectors.toCollection(FXCollections::observableArrayList));
+    }
+
+    private ListItem transformCustomerToListItem(Customer customer) {
+        String descriptionFormat = "Email: %s\nAddress: %s";
+        return new ListItem(String.format("[%d] %s", customer.getCustomerId(), customer.getName()),
+            String.format(descriptionFormat,
+                customer.getEmail().toString(),
+                customer.getAddress().toString()),
+            customer.getPhone().toString());
     }
 
     @Override
@@ -142,6 +147,7 @@ public class ModelManager implements Model {
         return userPrefs.getDeliveryBookFilePath();
     }
 
+    @Deprecated
     @Override
     public Delivery getDeliveryUsingFilteredList(int id) {
         for (Delivery d : filteredDeliveries) {
@@ -191,6 +197,7 @@ public class ModelManager implements Model {
         return this.addressBook.getById(id);
     }
 
+    @Deprecated
     @Override
     public Customer getCustomerUsingFilteredList(int id) {
         for (Customer c : filteredCustomers) {
@@ -263,6 +270,34 @@ public class ModelManager implements Model {
         }
 
         setUiListCustomer();
+    }
+
+    /**
+     * Resets the customer list to all customers.
+     */
+    @Override
+    public void showAllFilteredCustomerList() {
+        updateFilteredCustomerList(PREDICATE_SHOW_ALL_CUSTOMERS);
+    }
+
+    /**
+     * Returns the number of customers in the filtered customer list.
+     *
+     * @return the number of customers in the filtered customer list.
+     */
+    @Override
+    public int getFilteredCustomerListSize() {
+        return this.filteredCustomers.size();
+    }
+
+    /**
+     * Returns true if the filtered customer list is empty.
+     *
+     * @return true if the filtered customer list is empty.
+     */
+    @Override
+    public boolean isFilteredCustomerListEmpty() {
+        return this.filteredCustomers.isEmpty();
     }
 
     //=========== User Related Methods =======================================================================
@@ -418,6 +453,44 @@ public class ModelManager implements Model {
 
         deliveryBook.setDelivery(target, editedDelivery);
         updateFilteredDeliveryList(PREDICATE_SHOW_ALL_DELIVERIES);
+    }
+
+    /**
+     * Resets the delivery list to show all deliveries.
+     */
+    @Override
+    public void showAllFilteredDeliveryList() {
+        updateFilteredDeliveryList(PREDICATE_SHOW_ALL_DELIVERIES);
+    }
+
+    /**
+     * Returns the number of deliveries in the filtered delivery list.
+     *
+     * @return the number of deliveries in the filtered delivery list.
+     */
+    @Override
+    public int getFilteredDeliveryListSize() {
+        return this.filteredDeliveries.size();
+    }
+
+    /**
+     * Returns true if the filtered delivery list is empty.
+     *
+     * @return true if the filtered delivery list is empty.
+     */
+    @Override
+    public boolean isFilteredDeliveryListEmpty() {
+        return this.filteredDeliveries.isEmpty();
+    }
+
+    /**
+     * Returns the number of deliveries in the sorted delivery list.
+     *
+     * @return the number of deliveries in the sorted delivery list.
+     */
+    @Override
+    public boolean isSortedDeliveryListEmpty() {
+        return this.sortedDeliveries.isEmpty();
     }
 
     //=========== Filtered Customer List Accessors =============================================================

--- a/src/test/java/seedu/address/logic/commands/DeliveryAddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeliveryAddCommandTest.java
@@ -56,14 +56,14 @@ public class DeliveryAddCommandTest {
         CommandResult commandResult = null;
         try {
             commandResult = new DeliveryAddCommand(deliveryAddDescriptor)
-                    .execute(modelStub);
+                .execute(modelStub);
         } catch (CommandException e) {
             e.printStackTrace();
         }
 
 
         assertEquals(String.format(DeliveryAddCommand.MESSAGE_SUCCESS, Messages
-                .format(modelStub.getDelivery(0).get())), commandResult.getFeedbackToUser());
+            .format(modelStub.getDelivery(0).get())), commandResult.getFeedbackToUser());
 
     }
 
@@ -76,10 +76,10 @@ public class DeliveryAddCommandTest {
         Delivery validDelivery = new DeliveryBuilder().withCustomer(invalidCustomer).build();
 
         DeliveryAddCommand deliveryAddCommand = new DeliveryAddCommand(
-                new DeliveryAddDescriptorBuilder(validDelivery).build());
+            new DeliveryAddDescriptorBuilder(validDelivery).build());
 
         assertThrows(CommandException.class, Messages.MESSAGE_INVALID_CUSTOMER_DISPLAYED_INDEX, () ->
-                deliveryAddCommand.execute(modelStub));
+            deliveryAddCommand.execute(modelStub));
     }
 
     @Test
@@ -89,14 +89,14 @@ public class DeliveryAddCommandTest {
 
         ModelStub modelStub = new ModelStubAcceptingDeliveryAdded();
         Delivery validDelivery =
-                new DeliveryBuilder().withCustomer(validCustomer)
-                        .withDeliveryDate(INVALID_DELIVERY_DATE).build();
+            new DeliveryBuilder().withCustomer(validCustomer)
+                .withDeliveryDate(INVALID_DELIVERY_DATE).build();
 
         DeliveryAddCommand deliveryAddCommand = new DeliveryAddCommand(new
-                DeliveryAddDescriptorBuilder(validDelivery).build());
+            DeliveryAddDescriptorBuilder(validDelivery).build());
 
         assertThrows(CommandException.class, Messages.MESSAGE_INVALID_DELIVERY_DATE, () ->
-                deliveryAddCommand.execute(modelStub));
+            deliveryAddCommand.execute(modelStub));
     }
 
     @Test
@@ -108,9 +108,9 @@ public class DeliveryAddCommandTest {
         Delivery validDelivery = new DeliveryBuilder().withCustomer(validCustomer).build();
 
         DeliveryAddCommand deliveryAddCommand = new DeliveryAddCommand(new
-                DeliveryAddDescriptorBuilder(validDelivery).build());
+            DeliveryAddDescriptorBuilder(validDelivery).build());
         assertThrows(CommandException.class, Messages.MESSAGE_USER_NOT_AUTHENTICATED, () ->
-                deliveryAddCommand.execute(modelStub));
+            deliveryAddCommand.execute(modelStub));
 
     }
 
@@ -146,8 +146,8 @@ public class DeliveryAddCommandTest {
         DeliveryAddDescriptor deliveryAddDescriptor = new DeliveryAddDescriptorBuilder().build();
         DeliveryAddCommand deliveryAddCommand = new DeliveryAddCommand(deliveryAddDescriptor);
         String expected = new ToStringBuilder(deliveryAddCommand)
-                .add("toAdd", deliveryAddDescriptor)
-                .toString();
+            .add("toAdd", deliveryAddDescriptor)
+            .toString();
         assertEquals(expected, deliveryAddCommand.toString());
     }
 
@@ -266,6 +266,34 @@ public class DeliveryAddCommandTest {
             throw new AssertionError("This method should not be called.");
         }
 
+        /**
+         * Resets the customer list to all customers.
+         */
+        @Override
+        public void showAllFilteredCustomerList() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        /**
+         * Returns the number of customers in the filtered customer list.
+         *
+         * @return the number of customers in the filtered customer list.
+         */
+        @Override
+        public int getFilteredCustomerListSize() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        /**
+         * Returns true if the filtered customer list is empty.
+         *
+         * @return true if the filtered customer list is empty.
+         */
+        @Override
+        public boolean isFilteredCustomerListEmpty() {
+            throw new AssertionError("This method should not be called.");
+        }
+
         @Override
         public Path getDeliveryBookFilePath() {
             throw new AssertionError("This method should not be called.");
@@ -313,6 +341,44 @@ public class DeliveryAddCommandTest {
 
         @Override
         public void setDelivery(Delivery target, Delivery editedCustomer) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        /**
+         * Resets the delivery list to show all deliveries.
+         */
+        @Override
+        public void showAllFilteredDeliveryList() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        /**
+         * Returns the number of deliveries in the filtered delivery list.
+         *
+         * @return the number of deliveries in the filtered delivery list.
+         */
+        @Override
+        public int getFilteredDeliveryListSize() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        /**
+         * Returns true if the filtered delivery list is empty.
+         *
+         * @return true if the filtered delivery list is empty.
+         */
+        @Override
+        public boolean isFilteredDeliveryListEmpty() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        /**
+         * Returns the number of deliveries in the sorted delivery list.
+         *
+         * @return the number of deliveries in the sorted delivery list.
+         */
+        @Override
+        public boolean isSortedDeliveryListEmpty() {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/seedu/address/logic/commands/customer/CustomerAddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/customer/CustomerAddCommandTest.java
@@ -46,7 +46,7 @@ public class CustomerAddCommandTest {
         CommandResult commandResult = new CustomerAddCommand(validCustomer).execute(modelStub);
 
         assertEquals(String.format(CustomerAddCommand.MESSAGE_SUCCESS, Messages.format(validCustomer)),
-                commandResult.getFeedbackToUser());
+            commandResult.getFeedbackToUser());
         assertEquals(Arrays.asList(validCustomer), modelStub.customersAdded);
     }
 
@@ -58,7 +58,7 @@ public class CustomerAddCommandTest {
 
 
         assertThrows(CommandException.class,
-                CustomerAddCommand.MESSAGE_DUPLICATE_CUSTOMER, () -> customerAddCommand.execute(modelStub));
+            CustomerAddCommand.MESSAGE_DUPLICATE_CUSTOMER, () -> customerAddCommand.execute(modelStub));
 
     }
 
@@ -70,7 +70,7 @@ public class CustomerAddCommandTest {
         CustomerAddCommand customerAddCommand = new CustomerAddCommand(validCustomer);
 
         assertThrows(CommandException.class,
-                Messages.MESSAGE_USER_NOT_AUTHENTICATED, () -> customerAddCommand.execute(modelStub));
+            Messages.MESSAGE_USER_NOT_AUTHENTICATED, () -> customerAddCommand.execute(modelStub));
     }
 
     @Test
@@ -208,6 +208,34 @@ public class CustomerAddCommandTest {
             throw new AssertionError("This method should not be called.");
         }
 
+        /**
+         * Resets the customer list to all customers.
+         */
+        @Override
+        public void showAllFilteredCustomerList() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        /**
+         * Returns the number of customers in the filtered customer list.
+         *
+         * @return the number of customers in the filtered customer list.
+         */
+        @Override
+        public int getFilteredCustomerListSize() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        /**
+         * Returns true if the filtered customer list is empty.
+         *
+         * @return true if the filtered customer list is empty.
+         */
+        @Override
+        public boolean isFilteredCustomerListEmpty() {
+            throw new AssertionError("This method should not be called.");
+        }
+
         @Override
         public Path getDeliveryBookFilePath() {
             throw new AssertionError("This method should not be called.");
@@ -255,6 +283,44 @@ public class CustomerAddCommandTest {
 
         @Override
         public void setDelivery(Delivery target, Delivery editedCustomer) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        /**
+         * Resets the delivery list to show all deliveries.
+         */
+        @Override
+        public void showAllFilteredDeliveryList() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        /**
+         * Returns the number of deliveries in the filtered delivery list.
+         *
+         * @return the number of deliveries in the filtered delivery list.
+         */
+        @Override
+        public int getFilteredDeliveryListSize() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        /**
+         * Returns true if the filtered delivery list is empty.
+         *
+         * @return true if the filtered delivery list is empty.
+         */
+        @Override
+        public boolean isFilteredDeliveryListEmpty() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        /**
+         * Returns the number of deliveries in the sorted delivery list.
+         *
+         * @return the number of deliveries in the sorted delivery list.
+         */
+        @Override
+        public boolean isSortedDeliveryListEmpty() {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -273,7 +273,7 @@ public class ModelManagerTest {
         modelManager.setLoginSuccess();
         modelManager.addCustomer(ALICE);
         modelManager.addCustomer(BENSON);
-        modelManager.updateFilteredCustomerList(PREDICATE_SHOW_ALL_CUSTOMERS);
+        modelManager.showAllFilteredCustomerList();
         assertEquals(Arrays.asList(ALICE, BENSON), modelManager.getFilteredCustomerList());
     }
 
@@ -282,7 +282,7 @@ public class ModelManagerTest {
         modelManager.setLoginSuccess();
         modelManager.addDelivery(GABRIELS_MILK);
         modelManager.addDelivery(GAMBES_RICE);
-        modelManager.updateFilteredDeliveryList(PREDICATE_SHOW_ALL_DELIVERIES);
+        modelManager.showAllFilteredDeliveryList();
         assertEquals(Arrays.asList(GABRIELS_MILK, GAMBES_RICE), modelManager.getFilteredDeliveryList());
     }
 

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -5,6 +5,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_CUSTOMERS;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_DELIVERIES;
+import static seedu.address.model.Model.PREDICATE_SHOW_NO_CUSTOMERS;
+import static seedu.address.model.Model.PREDICATE_SHOW_NO_DELIVERIES;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalCustomers.ALICE;
 import static seedu.address.testutil.TypicalCustomers.BENSON;
@@ -219,7 +221,7 @@ public class ModelManagerTest {
     public void equals() {
         AddressBook addressBook = new AddressBookBuilder().withCustomer(ALICE).withCustomer(BENSON).build();
         DeliveryBook deliveryBook =
-                new DeliveryBookBuilder().withDelivery(GABRIELS_MILK).withDelivery(GAMBES_RICE).build();
+            new DeliveryBookBuilder().withDelivery(GABRIELS_MILK).withDelivery(GAMBES_RICE).build();
         AddressBook differentAddressBook = new AddressBook();
         DeliveryBook differentDeliveryBook = new DeliveryBook();
         UserPrefs userPrefs = new UserPrefs();
@@ -267,6 +269,78 @@ public class ModelManagerTest {
     }
 
     @Test
+    public void showAllCustomerList_success() {
+        modelManager.setLoginSuccess();
+        modelManager.addCustomer(ALICE);
+        modelManager.addCustomer(BENSON);
+        modelManager.updateFilteredCustomerList(PREDICATE_SHOW_ALL_CUSTOMERS);
+        assertEquals(Arrays.asList(ALICE, BENSON), modelManager.getFilteredCustomerList());
+    }
+
+    @Test
+    public void showAllDeliveryList_success() {
+        modelManager.setLoginSuccess();
+        modelManager.addDelivery(GABRIELS_MILK);
+        modelManager.addDelivery(GAMBES_RICE);
+        modelManager.updateFilteredDeliveryList(PREDICATE_SHOW_ALL_DELIVERIES);
+        assertEquals(Arrays.asList(GABRIELS_MILK, GAMBES_RICE), modelManager.getFilteredDeliveryList());
+    }
+
+    @Test
+    public void getFilteredCustomerListSize_success() {
+        modelManager.setLoginSuccess();
+        modelManager.addCustomer(ALICE);
+        modelManager.addCustomer(BENSON);
+        modelManager.updateFilteredCustomerList(PREDICATE_SHOW_ALL_CUSTOMERS);
+        assertEquals(2, modelManager.getFilteredCustomerListSize());
+    }
+
+    @Test
+    public void getFilteredDeliveryListSize_success() {
+        modelManager.setLoginSuccess();
+        modelManager.addDelivery(GABRIELS_MILK);
+        modelManager.addDelivery(GAMBES_RICE);
+        modelManager.updateFilteredDeliveryList(PREDICATE_SHOW_ALL_DELIVERIES);
+        assertEquals(2, modelManager.getFilteredDeliveryListSize());
+    }
+
+    @Test
+    public void isFilteredCustomerListEmpty_success() {
+        modelManager.setLoginSuccess();
+        modelManager.addCustomer(ALICE);
+        modelManager.addCustomer(BENSON);
+        modelManager.updateFilteredCustomerList(PREDICATE_SHOW_ALL_CUSTOMERS);
+        assertFalse(modelManager.isFilteredCustomerListEmpty());
+
+        modelManager.updateFilteredCustomerList(PREDICATE_SHOW_NO_CUSTOMERS);
+        assertTrue(modelManager.isFilteredCustomerListEmpty());
+    }
+
+    @Test
+    public void isFilteredDeliveryListEmpty_success() {
+        modelManager.setLoginSuccess();
+        modelManager.addDelivery(GABRIELS_MILK);
+        modelManager.addDelivery(GAMBES_RICE);
+        modelManager.updateFilteredDeliveryList(PREDICATE_SHOW_ALL_DELIVERIES);
+        assertFalse(modelManager.isFilteredDeliveryListEmpty());
+
+        modelManager.updateFilteredDeliveryList(PREDICATE_SHOW_NO_DELIVERIES);
+        assertTrue(modelManager.isFilteredDeliveryListEmpty());
+    }
+
+    @Test
+    public void isSortedDeliveryListEmpty_success() {
+        modelManager.setLoginSuccess();
+        modelManager.addDelivery(GABRIELS_MILK);
+        modelManager.addDelivery(GAMBES_RICE);
+        modelManager.sortFilteredDeliveryList(Comparator.comparing(Delivery::getName));
+        assertFalse(modelManager.isSortedDeliveryListEmpty());
+
+        modelManager.sortFilteredDeliveryList(Comparator.comparing(Delivery::getName).reversed());
+        assertFalse(modelManager.isSortedDeliveryListEmpty());
+    }
+
+    @Test
     public void getDelivery_returnsDelivery() {
         modelManager.addDelivery(GABRIELS_MILK);
         assertEquals(modelManager.getDelivery(1), Optional.of(GABRIELS_MILK));
@@ -286,7 +360,7 @@ public class ModelManagerTest {
     public void getLoginStatus_storedUserAndLoggedIn_success() {
         AddressBook addressBook = new AddressBookBuilder().withCustomer(ALICE).withCustomer(BENSON).build();
         DeliveryBook deliveryBook =
-                new DeliveryBookBuilder().withDelivery(GABRIELS_MILK).withDelivery(GAMBES_RICE).build();
+            new DeliveryBookBuilder().withDelivery(GABRIELS_MILK).withDelivery(GAMBES_RICE).build();
         UserPrefs userPrefs = new UserPrefs();
         userPrefs.setAuthenticationFilePath(Paths.get("src/test/data/Authentication", "authentication.json"));
         Model modelManager = new ModelManager(addressBook, deliveryBook, userPrefs, true);
@@ -302,7 +376,7 @@ public class ModelManagerTest {
     public void getLoginStatus_storedUserAndLoggedOut_success() {
         AddressBook addressBook = new AddressBookBuilder().withCustomer(ALICE).withCustomer(BENSON).build();
         DeliveryBook deliveryBook =
-                new DeliveryBookBuilder().withDelivery(GABRIELS_MILK).withDelivery(GAMBES_RICE).build();
+            new DeliveryBookBuilder().withDelivery(GABRIELS_MILK).withDelivery(GAMBES_RICE).build();
         UserPrefs userPrefs = new UserPrefs();
         userPrefs.setAuthenticationFilePath(Paths.get("src/test/data/Authentication", "authentication.json"));
         Model modelManager = new ModelManager(addressBook, deliveryBook, userPrefs, false);
@@ -318,7 +392,7 @@ public class ModelManagerTest {
     public void getLoginStatus_noStoredUser_success() {
         AddressBook addressBook = new AddressBookBuilder().withCustomer(ALICE).withCustomer(BENSON).build();
         DeliveryBook deliveryBook =
-                new DeliveryBookBuilder().withDelivery(GABRIELS_MILK).withDelivery(GAMBES_RICE).build();
+            new DeliveryBookBuilder().withDelivery(GABRIELS_MILK).withDelivery(GAMBES_RICE).build();
         UserPrefs userPrefs = new UserPrefs();
         userPrefs.setAuthenticationFilePath(Paths.get("src/test/data/Authentication", "authentication.json"));
         Model modelManager = new ModelManager(addressBook, deliveryBook, userPrefs, false);


### PR DESCRIPTION
Closes #490 

# Cleanup Model Manager

## New Methods

### Customer
1. `showAllCustomerList()`
May impact: `CustomerEditCommand`, `CustomerListCommand`, `UserLoginCommand`

3. `getFilteredCustomerListSize()`
May impact: `CustomerFind`

5.  `isFilteredCustomerListEmpty()`
May impact: `CustomerList`

### Delivery
1. `showAllDeliveryList()`
May impact: `DeliveryEditCommand`, `DeliveryListCommand`

3. `getFilteredDeliveryListSize()`

5. `isFilteredDeliveryListEmpty()`

7. `isSortedDeliveryListEmpty()`

## Other Changes
1. Extracted out transformers for LOD
2. Refractor guard statements to emphasise happy paths instead

