### PR TITLE
Add More Testing for missing pathways

### DIFF
--- a/src/test/java/seedu/address/logic/commands/delivery/DeliveryFindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/delivery/DeliveryFindCommandTest.java
@@ -96,6 +96,15 @@ public class DeliveryFindCommandTest {
         assertCommandFailure(command, model, Messages.MESSAGE_USER_NOT_AUTHENTICATED);
     }
 
+    @Test
+    public void toStringMethod() {
+        DeliveryNameContainsKeywordsPredicate predicate = preparePredicate("Kurz Elle Kunz");
+        String expected = DeliveryFindCommand.class.getCanonicalName()
+            + "{predicate=" + predicate + "}";
+        DeliveryFindCommand deliveryFindCommand = new DeliveryFindCommand(predicate);
+        assertEquals(expected, deliveryFindCommand.toString());
+    }
+
     /**
      * Parses {@code userInput} into a {@code DeliveryNameContainsKeywordsPredicate}.
      */

--- a/src/test/java/seedu/address/logic/parser/delivery/DeliveryStatusCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/delivery/DeliveryStatusCommandParserTest.java
@@ -116,4 +116,9 @@ public class DeliveryStatusCommandParserTest {
         assertParseFailure(parser,
             "1 1 " + INVALID_STATUS, MESSAGE_INVALID_FORMAT);
     }
+
+    @Test
+    public void parse_extraArgs_failure() {
+        assertParseFailure(parser, "", MESSAGE_INVALID_FORMAT);
+    }
 }

--- a/src/test/java/seedu/address/model/customer/UniqueCustomerListTest.java
+++ b/src/test/java/seedu/address/model/customer/UniqueCustomerListTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.Test;
 
 import seedu.address.model.customer.exceptions.CustomerNotFoundException;
 import seedu.address.model.customer.exceptions.DuplicateCustomerException;
+import seedu.address.model.delivery.UniqueDeliveryList;
 import seedu.address.testutil.CustomerBuilder;
 
 public class UniqueCustomerListTest {
@@ -229,5 +230,31 @@ public class UniqueCustomerListTest {
     @Test
     public void toStringMethod() {
         assertEquals(uniqueCustomerList.asUnmodifiableObservableList().toString(), uniqueCustomerList.toString());
+    }
+
+    @Test
+    public void equals() {
+        UniqueCustomerList firstList = new UniqueCustomerList();
+        UniqueCustomerList secondList = new UniqueCustomerList();
+        UniqueDeliveryList deliveryList = new UniqueDeliveryList();
+
+        // same list -> true
+        assertTrue(firstList.equals(firstList));
+
+        // different list both empty -> true
+        assertTrue(firstList.equals(secondList));
+
+        // different list -> false
+        assertFalse(firstList.equals(deliveryList));
+
+        secondList.add(ALICE);
+
+        // different items -> false
+        assertFalse(firstList.equals(secondList));
+
+        firstList.add(ALICE);
+
+        // same items -> true
+        assertTrue(firstList.equals(secondList));
     }
 }

--- a/src/test/java/seedu/address/model/delivery/NoteTest.java
+++ b/src/test/java/seedu/address/model/delivery/NoteTest.java
@@ -1,5 +1,6 @@
 package seedu.address.model.delivery;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
@@ -13,9 +14,16 @@ public class NoteTest {
     }
 
     @Test
-    public void constructor_invalidName_throwsIllegalArgumentException() {
-        String invalidName = "";
-        assertThrows(IllegalArgumentException.class, () -> new Note(invalidName));
+    public void constructor_invalidNote_throwsIllegalArgumentException() {
+        String invalidNote = "";
+        assertThrows(IllegalArgumentException.class, () -> new Note(invalidNote));
+    }
+
+    @Test
+    public void getNote_returnsNote() {
+        String validNote = "FedEx";
+        Note note = new Note(validNote);
+        assertEquals(validNote, note.getNote());
     }
 
     @Test

--- a/src/test/java/seedu/address/model/delivery/UniqueDeliveryListTest.java
+++ b/src/test/java/seedu/address/model/delivery/UniqueDeliveryListTest.java
@@ -15,6 +15,7 @@ import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.model.customer.UniqueCustomerList;
 import seedu.address.model.delivery.exceptions.DeliveryNotFoundException;
 import seedu.address.model.delivery.exceptions.DuplicateDeliveryException;
 import seedu.address.testutil.DeliveryBuilder;
@@ -200,5 +201,31 @@ public class UniqueDeliveryListTest {
     @Test
     public void toStringMethod() {
         assertEquals(uniqueDeliveryList.asUnmodifiableObservableList().toString(), uniqueDeliveryList.toString());
+    }
+
+    @Test
+    public void equals() {
+        UniqueDeliveryList firstList = new UniqueDeliveryList();
+        UniqueDeliveryList secondList = new UniqueDeliveryList();
+        UniqueCustomerList customerList = new UniqueCustomerList();
+
+        // same list -> true
+        assertTrue(firstList.equals(firstList));
+
+        // different list both empty -> true
+        assertTrue(firstList.equals(secondList));
+
+        // different list -> false
+        assertFalse(firstList.equals(customerList));
+
+        secondList.add(GAMBES_RICE);
+
+        // different items -> false
+        assertFalse(firstList.equals(secondList));
+
+        firstList.add(GAMBES_RICE);
+
+        // same items -> true
+        assertTrue(firstList.equals(secondList));
     }
 }

--- a/src/test/java/seedu/address/storage/JsonDeliveryBookStorageTest.java
+++ b/src/test/java/seedu/address/storage/JsonDeliveryBookStorageTest.java
@@ -42,7 +42,7 @@ public class JsonDeliveryBookStorageTest {
     }
 
     @Test
-    public void readAddressBook_nullFilePath_throwsNullPointerException() {
+    public void readDeliveryBook_nullFilePath_throwsNullPointerException() {
         assertThrows(NullPointerException.class, () -> readDeliveryBook(null));
     }
 
@@ -50,6 +50,21 @@ public class JsonDeliveryBookStorageTest {
         JsonDeliveryBookStorage jsonDeliveryBookStorage = new JsonDeliveryBookStorage(Paths.get(filePath));
         jsonDeliveryBookStorage.setReferencingBook(getTypicalAddressBook());
         return jsonDeliveryBookStorage.readBook(addToTestDataPathIfNotNull(filePath));
+    }
+
+    @Test
+    public void readDeliveryBook_emptyReferenceBook_throwsDataLoadingException() {
+        Path filePath = testFolder.resolve("TempDeliveryBook.json");
+        JsonDeliveryBookStorage jsonDeliveryBookStorage = new JsonDeliveryBookStorage(filePath);
+        assertThrows(DataLoadingException.class, jsonDeliveryBookStorage::readBook);
+    }
+
+    @Test
+    public void readDeliveryBookWithPath_emptyReferenceBook_throwsDataLoadingException() {
+        Path filePath = testFolder.resolve("TempDeliveryBook.json");
+        JsonDeliveryBookStorage jsonDeliveryBookStorage = new JsonDeliveryBookStorage(filePath);
+        assertThrows(DataLoadingException.class, ()
+            -> jsonDeliveryBookStorage.readBook(addToTestDataPathIfNotNull(filePath.toString())));
     }
 
     private Path addToTestDataPathIfNotNull(String prefsFileInTestDataFolder) {


### PR DESCRIPTION
- `DeliveryStatusCommandParser` empty args.
- `UniqueCustomerList` equals().
- `UniqueDeliveryList` equals().
- `Note` getNote().
- `DeliveryFindCommand` toString().
- `JsonDeliveryBookStorage` read from empty reference.

Closes #524.